### PR TITLE
fix memory leak and maintain joysticks list

### DIFF
--- a/src/QJoysticks/SDL_Joysticks.cpp
+++ b/src/QJoysticks/SDL_Joysticks.cpp
@@ -89,14 +89,7 @@ SDL_Joysticks::~SDL_Joysticks()
  */
 QList<QJoystickDevice*> SDL_Joysticks::joysticks()
 {
-    QList<QJoystickDevice*> list;
-
-#ifdef SDL_SUPPORTED
-    for (int i = 0; i < SDL_NumJoysticks(); ++i)
-        list.append (getJoystick (i));
-#endif
-
-    return list;
+    return m_joysticks;
 }
 
 /**
@@ -133,6 +126,8 @@ void SDL_Joysticks::update()
         case SDL_JOYDEVICEREMOVED:
             SDL_JoystickClose (SDL_JoystickOpen (event.jdevice.which));
             SDL_GameControllerClose (SDL_GameControllerOpen (event.cdevice.which));
+            delete m_joysticks[event.cdevice.which];
+            m_joysticks.removeAt(event.cdevice.which);
             emit countChanged();
             break;
         case SDL_JOYAXISMOTION:
@@ -187,6 +182,8 @@ void SDL_Joysticks::configureJoystick (const SDL_Event* event)
 
     SDL_GameControllerOpen (event->cdevice.which);
 
+    m_joysticks.append(getJoystick(event->cdevice.which));
+    
     ++m_tracker;
     emit countChanged();
 #else
@@ -270,7 +267,6 @@ QJoystickPOVEvent SDL_Joysticks::getPOVEvent (const SDL_Event* sdl_event)
 
 #ifdef SDL_SUPPORTED
     event.pov = sdl_event->jhat.hat;
-    event.joystick = getJoystick (sdl_event->jdevice.which);
 
     switch (sdl_event->jhat.value) {
     case SDL_HAT_RIGHTUP:
@@ -301,6 +297,8 @@ QJoystickPOVEvent SDL_Joysticks::getPOVEvent (const SDL_Event* sdl_event)
         event.angle = -1;
         break;
     }
+    event.joystick = m_joysticks[sdl_event->cdevice.which];
+    event.joystick->axes[event.pov] = event.angle;
 #else
     Q_UNUSED (sdl_event);
 #endif
@@ -319,7 +317,8 @@ QJoystickAxisEvent SDL_Joysticks::getAxisEvent (const SDL_Event* sdl_event)
 #ifdef SDL_SUPPORTED
     event.axis = sdl_event->caxis.axis;
     event.value = static_cast<qreal> (sdl_event->caxis.value) / 32767;
-    event.joystick = getJoystick (sdl_event->cdevice.which);
+    event.joystick = m_joysticks[sdl_event->cdevice.which];
+    event.joystick->axes[event.axis] = event.value;
 #else
     Q_UNUSED (sdl_event);
 #endif
@@ -339,7 +338,8 @@ QJoystickButtonEvent SDL_Joysticks::getButtonEvent (const SDL_Event*
 #ifdef SDL_SUPPORTED
     event.button = sdl_event->jbutton.button;
     event.pressed = sdl_event->jbutton.state == SDL_PRESSED;
-    event.joystick = getJoystick (sdl_event->jdevice.which);
+    event.joystick = m_joysticks[sdl_event->cdevice.which];
+    event.joystick->axes[event.button] = event.pressed;
 #else
     Q_UNUSED (sdl_event);
 #endif

--- a/src/QJoysticks/SDL_Joysticks.h
+++ b/src/QJoysticks/SDL_Joysticks.h
@@ -71,7 +71,7 @@ private:
     QJoystickButtonEvent getButtonEvent (const SDL_Event* sdl_event);
 
     int m_tracker;
-    QList<QJoystickDevice> m_joysticks;
+    QList<QJoystickDevice*> m_joysticks;
 };
 
 #endif


### PR DESCRIPTION
I fixed the memory leak problem, but it seems cause error for the example program.  
I'm not familiar with QML, so please have a further examination.  
Besides, I strongly recommend to upgrade SDL version into 2.0.10+, because [Game Controller Database](https://github.com/gabomdq/SDL_GameControllerDB) no longer support older version, and some problem like [this issue](https://github.com/alex-spataru/QJoysticks/issues/5#issuecomment-628993811) is no longer a problem.  