### PR TITLE
Fix test app

### DIFF
--- a/QJoysticks.pro
+++ b/QJoysticks.pro
@@ -20,3 +20,4 @@
 # THE SOFTWARE.
 
 include ($$PWD/QJoysticks.pri)
+TEMPLATE = lib

--- a/tests/Test_QJoysticks.h
+++ b/tests/Test_QJoysticks.h
@@ -25,9 +25,9 @@ private slots:
       /* Configure our test device */
       QJoystickDevice device;
       device.name = "Test device";
-      device.numAxes = 6;
-      device.numPOVs = 0;
-      device.numButtons = 12;
+//      device.numAxes = 6;
+//      device.numPOVs = 0;
+//      device.numButtons = 12;
       device.blacklisted = false;
    }
 
@@ -48,9 +48,9 @@ private slots:
 
       /* Joystick properties should remain the same */
       QVERIFY(joysticks->getName(0) == device.name);
-      QVERIFY(joysticks->getNumAxes(0) == device.numAxes);
-      QVERIFY(joysticks->getNumPOVs(0) == device.numPOVs);
-      QVERIFY(joysticks->getNumButtons(0) == device.numButtons);
+      QVERIFY(joysticks->getNumAxes(0) == device.axes.count());
+      QVERIFY(joysticks->getNumPOVs(0) == device.povs.count());
+      QVERIFY(joysticks->getNumButtons(0) == device.buttons.count());
    }
 
    void checkBlacklistedCount()

--- a/tests/Tests.pro
+++ b/tests/Tests.pro
@@ -32,3 +32,5 @@ SOURCES += \
 
 HEADERS += \
     $$PWD/Test_QJoysticks.h
+
+TEMPLATE = app


### PR DESCRIPTION
I tried to run the test app and I realized that the struct `QJoystickDevice` had changed at some point in way that it was incompatible with its usage on tests. I also added explicit output format template to `.pro` files.

All the 8 tests passed after the change.
OS : Linux (Ubuntu)
Qt Version: 6.3
![image](https://user-images.githubusercontent.com/16466767/228067508-8e207997-6d2e-4a55-9e96-c81d43277281.png)
