### PR TITLE
fixed wrong axis mapping after reconnecting game controller

### DIFF
--- a/src/QJoysticks/SDL_Joysticks.cpp
+++ b/src/QJoysticks/SDL_Joysticks.cpp
@@ -165,17 +165,21 @@ void SDL_Joysticks::update()
 
             emit countChanged();
             break;
-         case SDL_JOYAXISMOTION:
-            if (!SDL_IsGameController(event.cdevice.which))
+         case SDL_JOYAXISMOTION: {
+            int device_index = m_joysticks[event.cdevice.which]->id;
+            if (!SDL_IsGameController(device_index))
             {
                emit axisEvent(getAxisEvent(&event));
             }
+        }
             break;
-         case SDL_CONTROLLERAXISMOTION:
-            if (SDL_IsGameController(event.cdevice.which))
+         case SDL_CONTROLLERAXISMOTION: {
+            int device_index = m_joysticks[event.cdevice.which]->id;
+            if (SDL_IsGameController(device_index))
             {
                emit axisEvent(getAxisEvent(&event));
             }
+        }
             break;
          case SDL_JOYBUTTONUP:
             emit buttonEvent(getButtonEvent(&event));


### PR DESCRIPTION
When I disconnected my controller and reconnected it again, the axes were wrongly mapped.

It turned out that the two variables *device_index* and *instance ID* got mixed up.
The function *SDL_IsGameController()* needs *joystick_index* (same as *device_index*) as an argument, but *instance ID* was given instead.

When connecting the controller the first time that's not a problem because *device_index* and *instance ID* are the same.
But *instance ID* counts up every time a new controller is connected while *device_index* doesn't. So from the second connection on the two variables differ.