### PR TITLE
Add Apple Silicon (arm64) support for macOS

### DIFF
--- a/lib/SDL/SDL.pri
+++ b/lib/SDL/SDL.pri
@@ -24,7 +24,27 @@ win32-msvc* {
 }
 
 macx* {
-    LIBS += -L$$PWD/bin/mac-osx/ -lSDL2
+    # Try to use system SDL2 via sdl2-config (works with Homebrew, MacPorts, etc.)
+    # Falls back to bundled library for Intel Macs if system SDL2 not found
+    SDL2_CONFIG = $$system(which sdl2-config 2>/dev/null)
+    !isEmpty(SDL2_CONFIG) {
+        # Use system SDL2 (required for Apple Silicon, recommended for all)
+        QMAKE_CFLAGS += $$system(sdl2-config --cflags)
+        QMAKE_CXXFLAGS += $$system(sdl2-config --cflags)
+        LIBS += $$system(sdl2-config --libs)
+    } else {
+        # Fallback: Try Homebrew paths (arm64: /opt/homebrew, x86_64: /usr/local)
+        exists(/opt/homebrew/lib/libSDL2.dylib) {
+            INCLUDEPATH += /opt/homebrew/include/SDL2
+            LIBS += -L/opt/homebrew/lib -lSDL2
+        } else:exists(/usr/local/lib/libSDL2.dylib) {
+            INCLUDEPATH += /usr/local/include/SDL2
+            LIBS += -L/usr/local/lib -lSDL2
+        } else {
+            # Last resort: use bundled library (x86_64 only, won't work on Apple Silicon)
+            LIBS += -L$$PWD/bin/mac-osx/ -lSDL2
+        }
+    }
 
     LIBS += -framework AudioToolbox
     LIBS += -framework AudioUnit
@@ -36,6 +56,8 @@ macx* {
     LIBS += -framework Carbon
     LIBS += -framework ForceFeedback
     LIBS += -framework CoreVideo
+    LIBS += -framework GameController
+    LIBS += -framework CoreHaptics
 
     QMAKE_LFLAGS += -F /System/Library/Frameworks/AudioToolbox.framework/
     QMAKE_LFLAGS += -F /System/Library/Frameworks/AudioUnit.framework/


### PR DESCRIPTION
## Summary

This PR adds support for Apple Silicon (arm64) Macs by using system-installed SDL2 instead of the bundled x86_64-only library.

### Problem

The bundled SDL2 library in `lib/SDL/bin/mac-osx/` is compiled for x86_64 only. On Apple Silicon Macs, this causes linker errors because the architecture doesn't match.

### Solution

Updated `SDL.pri` to:

1. **Use sdl2-config** when available - This automatically detects SDL2 installed via Homebrew, MacPorts, or other package managers and provides correct compiler/linker flags.

2. **Fallback to Homebrew paths** - If sdl2-config isn't available, check for SDL2 in:
   - `/opt/homebrew/lib` (Apple Silicon Homebrew)
   - `/usr/local/lib` (Intel Homebrew)

3. **Use bundled library as last resort** - Only falls back to the bundled x86_64 library if system SDL2 isn't found (won't work on Apple Silicon but maintains backward compatibility on Intel).

4. **Added required frameworks** - GameController and CoreHaptics frameworks required by modern SDL2 builds.

### Installation

For Apple Silicon Macs, install SDL2 via Homebrew:
```bash
brew install sdl2
```

### Testing

Tested on:
- macOS 15.7 on Apple Silicon (M4 Max)
- SDL2 2.32.10 via Homebrew
- Qt 6.10

🤖 Generated with [Claude Code](https://claude.ai/code)