### PR TITLE
Feat: Add CMake build system, shared/static library support, and GitHub Actions CI

### DIFF
--- a/.github/workflows/tag-build-artifacts.yml
+++ b/.github/workflows/tag-build-artifacts.yml
@@ -21,12 +21,10 @@ jobs:
         include:
           - runner: ubuntu-22.04
             arch: x86_64
-            qt_host: linux
             artifact_name: qjoysticks-linux-x86_64.tar.gz
             expected_file_arch: x86-64
           - runner: ubuntu-22.04-arm
             arch: aarch64
-            qt_host: linux_arm64
             artifact_name: qjoysticks-linux-aarch64.tar.gz
             expected_file_arch: aarch64
     runs-on: ${{ matrix.runner }}
@@ -37,23 +35,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install build tools
+      # Distro Qt (6.2.4 on Ubuntu 22.04) instead of Qt's official binaries:
+      # Qt's arm64 Linux binaries are built on Ubuntu 24.04 (glibc 2.38) and
+      # don't even run on this 22.04 runner. Building against the distro Qt
+      # keeps the glibc 2.35 baseline AND lets the lib load in any app using
+      # Qt >= 6.2 - widest compatibility.
+      - name: Install build tools and Qt
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             build-essential cmake ninja-build pkg-config \
+            qt6-base-dev \
             libasound2-dev libpulse-dev libdbus-1-dev libudev-dev \
             libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev \
             libxfixes-dev libxss-dev libxkbcommon-dev \
             libwayland-dev libegl1-mesa-dev libgl1-mesa-dev libdrm-dev libgbm-dev
-
-      - name: Install Qt ${{ env.QT_VERSION }}
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: ${{ env.QT_VERSION }}
-          host: ${{ matrix.qt_host }}
-          target: desktop
-          cache: true
 
       - name: Cache static SDL2
         id: cache-deps
@@ -153,6 +149,7 @@ jobs:
           fi
 
           glibc_version="$(ldd --version | head -n 1 | awk '{print $NF}')"
+          qt_version="$(dpkg-query -W -f='${Version}' qt6-base-dev | cut -d+ -f1)"
           build_timestamp="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
           cat > dist/BUILD-MANIFEST.txt <<EOF
@@ -160,7 +157,7 @@ jobs:
           target_arch=${{ matrix.arch }}
           min_distro=ubuntu-22.04 (glibc >= 2.35)
           build_glibc_version=${glibc_version}
-          qt_version=${QT_VERSION} (dynamic - consumer app provides Qt >= this version)
+          qt_version=${qt_version} (dynamic - consumer app provides Qt >= this version)
           sdl2_version=${SDL2_VERSION} (statically embedded)
           git_commit=${GITHUB_SHA}
           build_timestamp=${build_timestamp}

--- a/.github/workflows/tag-build-artifacts.yml
+++ b/.github/workflows/tag-build-artifacts.yml
@@ -1,0 +1,346 @@
+name: Build Artifacts On Tag
+
+on:
+  push:
+    tags:
+      - '**'
+
+permissions:
+  contents: write
+
+env:
+  QT_VERSION: 6.8.3
+  SDL2_VERSION: 2.32.10
+
+jobs:
+  build-linux:
+    name: Linux ${{ matrix.arch }} (SDL2 embedded .so)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            arch: x86_64
+            qt_host: linux
+            artifact_name: qjoysticks-linux-x86_64.tar.gz
+            expected_file_arch: x86-64
+          - runner: ubuntu-22.04-arm
+            arch: aarch64
+            qt_host: linux_arm64
+            artifact_name: qjoysticks-linux-aarch64.tar.gz
+            expected_file_arch: aarch64
+    runs-on: ${{ matrix.runner }}
+    env:
+      DEPS_PREFIX: ${{ github.workspace }}/.static-deps
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake ninja-build pkg-config \
+            libasound2-dev libpulse-dev libdbus-1-dev libudev-dev \
+            libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev \
+            libxfixes-dev libxss-dev libxkbcommon-dev \
+            libwayland-dev libegl1-mesa-dev libgl1-mesa-dev libdrm-dev libgbm-dev
+
+      - name: Install Qt ${{ env.QT_VERSION }}
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: ${{ matrix.qt_host }}
+          target: desktop
+          cache: true
+
+      - name: Cache static SDL2
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.DEPS_PREFIX }}
+          key: qjoysticks-static-sdl2-v1-${{ matrix.arch }}-${{ env.SDL2_VERSION }}
+
+      - name: Build static SDL2
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          curl -fsSLO "https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/SDL2-${SDL2_VERSION}.tar.gz"
+          tar xf "SDL2-${SDL2_VERSION}.tar.gz"
+          cmake -S "SDL2-${SDL2_VERSION}" -B sdl2-build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+            -DSDL_SHARED=OFF \
+            -DSDL_STATIC=ON \
+            -DSDL_STATIC_PIC=ON \
+            -DSDL_TEST=OFF
+          cmake --build sdl2-build --parallel
+          cmake --install sdl2-build
+
+      - name: Configure
+        run: >-
+          cmake -S . -B build
+          -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+          -DCMAKE_PREFIX_PATH="${DEPS_PREFIX}"
+          -DQJOYSTICKS_BUILD_SHARED=ON
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Validate self-contained .so
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          LIB_PATH="$(find build -type f -name 'libQJoysticks.so' | head -n 1)"
+          if [ -z "${LIB_PATH}" ]; then
+            echo "libQJoysticks.so not found"
+            exit 1
+          fi
+
+          mkdir -p dist/include/QJoysticks diagnostics
+          cp "${LIB_PATH}" dist/libQJoysticks.so
+          cp src/QJoysticks.h dist/include/
+          cp src/QJoysticks/JoysticksCommon.h dist/include/QJoysticks/
+
+          # 1) Architecture verification.
+          file dist/libQJoysticks.so | tee diagnostics/file.txt
+          if ! grep -q "${{ matrix.expected_file_arch }}" diagnostics/file.txt; then
+            echo "Architecture mismatch: expected ${{ matrix.expected_file_arch }}"
+            exit 1
+          fi
+
+          # 2) NEEDED entries: Qt + baseline system libraries only.
+          #    SDL2 must be embedded, never a runtime dependency.
+          readelf -d dist/libQJoysticks.so | tee diagnostics/readelf_dynamic.txt
+          awk '/NEEDED/ {gsub(/[\[\]]/, "", $NF); print $NF}' diagnostics/readelf_dynamic.txt \
+            | sort -u > diagnostics/needed.txt
+          cat diagnostics/needed.txt
+          while IFS= read -r lib; do
+            case "${lib}" in
+              libQt6Core.so.6|libQt6Gui.so.6|libQt6Widgets.so.6)
+                ;;
+              libstdc++.so.6|libgcc_s.so.1|libc.so.6|libm.so.6|libpthread.so.0|libdl.so.2|librt.so.1|ld-linux-*)
+                ;;
+              *)
+                echo "Unexpected runtime dependency: ${lib}"
+                exit 1
+                ;;
+            esac
+          done < diagnostics/needed.txt
+
+          # 3) Symbols: public C++ API exported, SDL2 internals hidden.
+          nm -CD --defined-only dist/libQJoysticks.so > diagnostics/nm_exports.txt
+          if ! grep -q 'QJoysticks::getInstance' diagnostics/nm_exports.txt; then
+            echo "QJoysticks C++ API not exported"
+            exit 1
+          fi
+          if nm -D --defined-only dist/libQJoysticks.so | awk '{print $3}' | grep -qE '^SDL_'; then
+            echo "SDL2 symbols leaked out of the library"
+            exit 1
+          fi
+
+          # 4) glibc compatibility: nothing newer than Ubuntu 22.04 (glibc 2.35).
+          strings dist/libQJoysticks.so | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -uV \
+            | tee diagnostics/glibc_symbols.txt
+          max_glibc="$(sed 's/GLIBC_//' diagnostics/glibc_symbols.txt | sort -V | tail -n 1)"
+          if [ -n "${max_glibc}" ] && [ "$(printf '%s\n2.35\n' "${max_glibc}" | sort -V | tail -n 1)" != "2.35" ]; then
+            echo "glibc requirement too new: ${max_glibc} (must be <= 2.35)"
+            exit 1
+          fi
+
+          glibc_version="$(ldd --version | head -n 1 | awk '{print $NF}')"
+          build_timestamp="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+          cat > dist/BUILD-MANIFEST.txt <<EOF
+          target_os=linux
+          target_arch=${{ matrix.arch }}
+          min_distro=ubuntu-22.04 (glibc >= 2.35)
+          build_glibc_version=${glibc_version}
+          qt_version=${QT_VERSION} (dynamic - consumer app provides Qt >= this version)
+          sdl2_version=${SDL2_VERSION} (statically embedded)
+          git_commit=${GITHUB_SHA}
+          build_timestamp=${build_timestamp}
+          EOF
+
+          tar -C dist -czf "${{ matrix.artifact_name }}" \
+            libQJoysticks.so \
+            include \
+            BUILD-MANIFEST.txt
+
+      - name: Upload Linux package
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: |
+            ${{ matrix.artifact_name }}
+            diagnostics/file.txt
+            diagnostics/needed.txt
+            diagnostics/nm_exports.txt
+            diagnostics/readelf_dynamic.txt
+            diagnostics/glibc_symbols.txt
+          if-no-files-found: error
+
+  build-windows:
+    name: Windows x64 (SDL2 embedded .dll)
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Qt ${{ env.QT_VERSION }}
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: windows
+          target: desktop
+          arch: win64_msvc2022_64
+          cache: true
+
+      - name: Install static SDL2 (vcpkg)
+        shell: pwsh
+        run: '& "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install sdl2:x64-windows-static-md --clean-after-build'
+
+      - name: Configure
+        shell: pwsh
+        run: |
+          $toolchain = Join-Path $env:VCPKG_INSTALLATION_ROOT 'scripts/buildsystems/vcpkg.cmake'
+          cmake -S . -B build -A x64 `
+            -DQJOYSTICKS_BUILD_SHARED=ON `
+            -DVCPKG_TARGET_TRIPLET=x64-windows-static-md `
+            "-DCMAKE_TOOLCHAIN_FILE=$toolchain"
+
+      - name: Build
+        shell: pwsh
+        run: cmake --build build --config Release --parallel
+
+      - name: Validate self-contained .dll
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dll = 'build/Release/QJoysticks.dll'
+          if (-not (Test-Path $dll)) { throw 'QJoysticks.dll not found' }
+          New-Item -ItemType Directory -Force -Path diagnostics | Out-Null
+
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $dumpbin = Get-ChildItem -Recurse "$vsPath\VC\Tools\MSVC" -Filter dumpbin.exe |
+            Where-Object { $_.FullName -match 'Hostx64\\x64' } |
+            Select-Object -First 1 -ExpandProperty FullName
+
+          # 1) Imports: SDL2 must be embedded. Qt and the CRT stay dynamic by
+          #    design - the consumer is a Qt/MSVC app and already ships those.
+          $deps = & $dumpbin /DEPENDENTS $dll
+          $deps | Out-File diagnostics\dependents.txt
+          Write-Host ($deps -join "`n")
+          if ($deps | Select-String -Pattern '(?i)sdl2') {
+            Write-Host 'SDL2.dll import found - SDL2 was not statically embedded'
+            exit 1
+          }
+          if (-not ($deps | Select-String -Pattern 'Qt6Core\.dll')) {
+            Write-Host 'Qt6Core.dll import missing - unexpected linkage'
+            exit 1
+          }
+
+          # 2) Exports: C++ API present, SDL2 internals hidden.
+          $exports = & $dumpbin /EXPORTS $dll
+          $exports | Out-File diagnostics\exports.txt
+          if (-not ($exports | Select-String -Pattern 'QJoysticks')) {
+            Write-Host 'QJoysticks C++ API not exported'
+            exit 1
+          }
+          if ($exports | Select-String -Pattern '\bSDL_[A-Za-z]') {
+            Write-Host 'SDL2 symbols leaked out of the library'
+            exit 1
+          }
+
+          # 3) Package.
+          New-Item -ItemType Directory -Force -Path dist\include\QJoysticks | Out-Null
+          Copy-Item $dll dist\
+          Copy-Item build/Release/QJoysticks.lib dist\
+          Copy-Item src\QJoysticks.h dist\include\
+          Copy-Item src\QJoysticks\JoysticksCommon.h dist\include\QJoysticks\
+          @(
+            'target_os=windows'
+            'target_arch=x64'
+            "qt_version=$env:QT_VERSION (dynamic - consumer app provides Qt >= this version, MSVC build)"
+            "sdl2_version=$env:SDL2_VERSION (statically embedded)"
+            'crt=dynamic (/MD, matches Qt)'
+            "git_commit=$env:GITHUB_SHA"
+            "build_timestamp=$([DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+          ) | Out-File dist\BUILD-MANIFEST.txt
+          Compress-Archive -Path dist\* -DestinationPath qjoysticks-windows-x64.zip
+
+      - name: Upload Windows package
+        uses: actions/upload-artifact@v4
+        with:
+          name: qjoysticks-windows-x64.zip
+          path: |
+            qjoysticks-windows-x64.zip
+            diagnostics/dependents.txt
+            diagnostics/exports.txt
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub Release (single SDK zip)
+    needs: [build-linux, build-windows]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download Linux x86_64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qjoysticks-linux-x86_64.tar.gz
+          path: dl/x86_64
+
+      - name: Download Linux aarch64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qjoysticks-linux-aarch64.tar.gz
+          path: dl/aarch64
+
+      - name: Download Windows x64 artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qjoysticks-windows-x64.zip
+          path: dl/win64
+
+      - name: Assemble single SDK package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Final layout:
+          #   lib/include/QJoysticks.h
+          #   lib/include/QJoysticks/JoysticksCommon.h
+          #   lib/linux_x86/libQJoysticks.so   (+ manifest)
+          #   lib/linux_aarch/libQJoysticks.so (+ manifest)
+          #   lib/win64/QJoysticks.dll + QJoysticks.lib (+ manifest)
+          mkdir -p lib/linux_x86 lib/linux_aarch lib/win64
+
+          tar xzf dl/x86_64/qjoysticks-linux-x86_64.tar.gz -C dl/x86_64
+          cp dl/x86_64/libQJoysticks.so dl/x86_64/BUILD-MANIFEST.txt lib/linux_x86/
+
+          tar xzf dl/aarch64/qjoysticks-linux-aarch64.tar.gz -C dl/aarch64
+          cp dl/aarch64/libQJoysticks.so dl/aarch64/BUILD-MANIFEST.txt lib/linux_aarch/
+
+          unzip -q dl/win64/qjoysticks-windows-x64.zip -d dl/win64/extracted
+          cp dl/win64/extracted/QJoysticks.dll \
+             dl/win64/extracted/QJoysticks.lib \
+             dl/win64/extracted/BUILD-MANIFEST.txt lib/win64/
+
+          # One shared header set (identical across platforms).
+          cp -r dl/x86_64/include lib/include
+
+          SAFE_TAG="${GITHUB_REF_NAME//\//-}"
+          zip -r "qjoysticks-${SAFE_TAG}.zip" lib
+          unzip -l "qjoysticks-${SAFE_TAG}.zip"
+
+      - name: Create release and upload single SDK zip
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: qjoysticks-*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ Temporary Items
 # Custom folders
 .vscode
 .build
+
+!.github/workflows/*.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,85 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(QJoysticks
+    VERSION 1.0.0
+    DESCRIPTION "Qt joystick input library (SDL2 statically embedded)"
+    LANGUAGES C CXX)
+
+option(QJOYSTICKS_BUILD_SHARED "Build QJoysticks as a shared library" ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
+find_package(SDL2 REQUIRED)
+
+# Prefer the regular target, but fall back to the static-only target so a
+# static SDL2 build (used for the self-contained library) works unchanged.
+if(TARGET SDL2::SDL2)
+    set(QJ_SDL2_TARGET SDL2::SDL2)
+elseif(TARGET SDL2::SDL2-static)
+    set(QJ_SDL2_TARGET SDL2::SDL2-static)
+elseif(SDL2_LIBRARIES)
+    set(QJ_SDL2_TARGET ${SDL2_LIBRARIES})
+else()
+    message(FATAL_ERROR "SDL2 was found but provides no usable target")
+endif()
+
+set(QJ_LIB_TYPE STATIC)
+if(QJOYSTICKS_BUILD_SHARED)
+    set(QJ_LIB_TYPE SHARED)
+endif()
+
+add_library(QJoysticks ${QJ_LIB_TYPE}
+    src/QJoysticks.cpp
+    src/QJoysticks/SDL_Joysticks.cpp
+    src/QJoysticks/VirtualJoystick.cpp
+    etc/resources/qjoysticks-res.qrc)
+
+target_include_directories(QJoysticks
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+        $<INSTALL_INTERFACE:include>)
+
+# Same defines the qmake build (QJoysticks.pri / lib/SDL/SDL.pri) uses.
+target_compile_definitions(QJoysticks PRIVATE SDL_SUPPORTED SDL_MAIN_HANDLED)
+if(WIN32)
+    target_compile_definitions(QJoysticks PRIVATE SDL_WIN)
+endif()
+
+target_link_libraries(QJoysticks
+    PUBLIC
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Widgets
+    PRIVATE
+        ${QJ_SDL2_TARGET})
+
+# Public API is C++ (no export macros in the sources), so export everything
+# on Windows via an auto-generated .def file.
+set_target_properties(QJoysticks PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+if(UNIX AND NOT APPLE AND QJOYSTICKS_BUILD_SHARED)
+    # Self-contained .so (apart from Qt and system libs):
+    #  - hide every symbol coming from the statically linked SDL2 archive so
+    #    it can never clash with an app's own SDL2
+    #  - fail the build if any symbol is left unresolved
+    # NOTE: the C++ API must stay exported, so do NOT use hidden visibility
+    # or static libstdc++ here.
+    target_link_options(QJoysticks PRIVATE
+        -Wl,--exclude-libs,ALL
+        -Wl,--no-undefined
+        -Wl,--as-needed)
+endif()
+
+include(GNUInstallDirs)
+install(TARGETS QJoysticks
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+# Only the headers consumers need: QJoysticks.h pulls in JoysticksCommon.h.
+# (SDL_Joysticks.h includes <SDL.h> and is intentionally not shipped.)
+install(FILES src/QJoysticks.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES src/QJoysticks/JoysticksCommon.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QJoysticks)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,14 @@ target_link_libraries(QJoysticks
     PRIVATE
         ${QJ_SDL2_TARGET})
 
-# Public API is C++ (no export macros in the sources), so export everything
-# on Windows via an auto-generated .def file.
-set_target_properties(QJoysticks PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+# Export the public QJoysticks class on Windows via QJOYSTICKS_EXPORT.
+# (WINDOWS_EXPORT_ALL_SYMBOLS is NOT used: it breaks with AUTORCC-generated
+# objects under the Visual Studio generator.)
+if(QJOYSTICKS_BUILD_SHARED)
+    target_compile_definitions(QJoysticks PRIVATE QJOYSTICKS_LIBRARY)
+else()
+    target_compile_definitions(QJoysticks PUBLIC QJOYSTICKS_STATIC)
+endif()
 
 if(UNIX AND NOT APPLE AND QJOYSTICKS_BUILD_SHARED)
     # Self-contained .so (apart from Qt and system libs):

--- a/QJoysticks.pri
+++ b/QJoysticks.pri
@@ -21,6 +21,9 @@
 
 include ($$PWD/lib/SDL/SDL.pri)
 
+# Sources are compiled directly into the app -> no dllexport/dllimport.
+DEFINES += QJOYSTICKS_STATIC
+
 QT += gui
 QT += core
 QT += widgets

--- a/src/QJoysticks.h
+++ b/src/QJoysticks.h
@@ -27,6 +27,20 @@
 #include <QStringList>
 #include <QJoysticks/JoysticksCommon.h>
 
+/* QJOYSTICKS_LIBRARY is defined while building the QJoysticks DLL (CMake).
+ * QJOYSTICKS_STATIC is defined when the sources are compiled directly into
+ * an app (QJoysticks.pri) or built as a static lib.
+ * Apps linking against the prebuilt DLL need no defines (-> dllimport). */
+#if defined(_WIN32) && !defined(QJOYSTICKS_STATIC)
+#  if defined(QJOYSTICKS_LIBRARY)
+#    define QJOYSTICKS_EXPORT __declspec(dllexport)
+#  else
+#    define QJOYSTICKS_EXPORT __declspec(dllimport)
+#  endif
+#else
+#  define QJOYSTICKS_EXPORT
+#endif
+
 class QSettings;
 class SDL_Joysticks;
 class VirtualJoystick;
@@ -48,7 +62,7 @@ class VirtualJoystick;
  * \note the virtual joystick will ALWAYS be the last joystick to be registered,
  *       even if it has been enabled before any SDL joystick has been attached.
  */
-class QJoysticks : public QObject
+class QJOYSTICKS_EXPORT QJoysticks : public QObject
 {
    Q_OBJECT
    Q_PROPERTY(int count READ count NOTIFY countChanged)


### PR DESCRIPTION
This PR updates the project configuration to support both shared and static library compilation types using CMake, while introducing automated CI/CD capabilities.

* **CMake Support:** Introduced `CMakeLists.txt` to seamlessly integrate with modern Qt6 and SDL2 development workflows.
* **Windows Exports:** Added symbol exporting handling (`QJOYSTICKS_EXPORT`) for Windows dynamic linking.
* **Release Pipeline:** Added a GitHub Actions workflow that triggers on tag pushes to compile, validate (checking glibc compatibility and symbol leakage), package, and host multi-architecture binaries (Linux x86_64/aarch64 and Windows x64) as a single unified SDK zip under GitHub Releases.